### PR TITLE
Fix typo in command line option --files-to-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ swift package generate-xcodeproj
 `SwiftCodeSan` is a commandline executable. To run it, pass in a list of the source file directories or file paths of a build target, and the destination filepath for the mock output. To see other arguments to the commandline, run `SwiftCodeSan --help`.
 
 ```
-./SwiftCodeSan --files-to-mouldes [file_to_module_list] --remove-deadcode --in-place
+./SwiftCodeSan --files-to-modules [file_to_module_list] --remove-deadcode --in-place
 ```
 The `file_to_module_list` contains a map of source file paths to corresponding module names.  Other input options are `--remote-unused-imports` and `--remove-public`.  If `--in-place` is set, files will be modified directly. 
 

--- a/Sources/SwiftCodeSan/Executor.swift
+++ b/Sources/SwiftCodeSan/Executor.swift
@@ -69,7 +69,7 @@ class Executor {
                                  kind: String.self,
                                  usage: "Log file path containing the analysis results. If no value is given, it will be saved to a tmp file.",
                                  completion: .filename)
-        fileLists = parser.add(option: "--files-to-mouldes",
+        fileLists = parser.add(option: "--files-to-modules",
                                shortName: "-f",
                                kind: [String].self,
                                usage: "File paths each containing a map of source files and corresponding module names.",


### PR DESCRIPTION
Changing
`--files-to-mouldes`
to
`--files-to-modules`