### PR TITLE
[DOCS] Fix typo on command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ swift package generate-xcodeproj
 ```
 ./SwiftCodeSan --files-to-modules [file_to_module_list] --remove-deadcode --in-place
 ```
-The `file_to_module_list` contains a map of source file paths to corresponding module names.  Other input options are `--remove-unused-imports` and `--remove-public`.  If `--in-place` is set, files will be modified directly. 
+The `file_to_module_list` contains a map of source file paths to corresponding module names.  Other input options are `--remove-unused-imports` and `--update-access-levels`.  If `--in-place` is set, files will be modified directly. 
 
 Use --help to see the complete list of argument options.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ swift package generate-xcodeproj
 ```
 ./SwiftCodeSan --files-to-modules [file_to_module_list] --remove-deadcode --in-place
 ```
-The `file_to_module_list` contains a map of source file paths to corresponding module names.  Other input options are `--remote-unused-imports` and `--remove-public`.  If `--in-place` is set, files will be modified directly. 
+The `file_to_module_list` contains a map of source file paths to corresponding module names.  Other input options are `--remove-unused-imports` and `--remove-public`.  If `--in-place` is set, files will be modified directly. 
 
 Use --help to see the complete list of argument options.
 


### PR DESCRIPTION
### Purpose 

- Fixes a typo encountered in the command example explanation - from `remote` to `remove`;

### Other possible typos:

- I've found out that the command `--remove-public` does not exist in the listing of commands, when you ask for the executable for it. Instead, it has `--update-access-levels` which sounds to be the updated one as per command description, but in command example it is not up to date - this one is not fixed in the PR, but if confirmed by main repository team, I can update and send together with this;