### PR TITLE
Fixed minLogLevel so that it is applied correctly

### DIFF
--- a/Sources/SwiftCodeSan/Executor.swift
+++ b/Sources/SwiftCodeSan/Executor.swift
@@ -136,6 +136,8 @@ struct Executor: ParsableCommand {
     }
 
     mutating func run() throws {
+        minLogLevel = loggingLevel
+
         var filesToModules = [String: String]()
         fileLists.forEach { arg in
             let line = arg.components(separatedBy: ":")


### PR DESCRIPTION
## Background

In #4, the process to apply minLogLevel was mistakenly removed.

https://github.com/uber/SwiftCodeSan/pull/4/files#diff-3855cbc80f99b2fb63586dfe0d3a19b643c67a6f0c6d18ea42707f845efa242eL177

## What I did.

- The minLogLevel is now reflected when Executor is run.