### PR TITLE
Upgrade SwiftSyntax to 5.6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
         "package": "SwiftSyntax",
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
-          "branch": "swift-5.5-RELEASE",
-          "revision": "cf40be70deaf4ce7d44eb1a7e14299c391e2363f",
+          "branch": "swift-5.6-RELEASE",
+          "revision": "87d6d0af3d2db26ce0d6014cd953e546d45f63c6",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.2")),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("swift-5.5-RELEASE"))
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("swift-5.6-RELEASE"))
     ],
     targets: [ 
         .target(
@@ -25,6 +25,7 @@ let package = Package(
             name: "SwiftCodeSanKit",
             dependencies: [
                 .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+                .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
             ]
         ),
         .testTarget(

--- a/Sources/SwiftCodeSanKit/FileParsers/DeclParser.swift
+++ b/Sources/SwiftCodeSanKit/FileParsers/DeclParser.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 
 public class DeclParser {
     

--- a/Sources/SwiftCodeSanKit/FileUpdaters/DeclUpdater.swift
+++ b/Sources/SwiftCodeSanKit/FileUpdaters/DeclUpdater.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 
 final class DeclUpdater {
 

--- a/Sources/SwiftCodeSanKit/Utils/Extensions/SyntaxParserExtensions.swift
+++ b/Sources/SwiftCodeSanKit/Utils/Extensions/SyntaxParserExtensions.swift
@@ -17,16 +17,17 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 
 extension SyntaxParser {
     public static func parse(_ fileData: Data, path: String,
-                             diagnosticEngine: DiagnosticEngine? = nil) throws -> SourceFileSyntax {
+                             diagnosticHandler: ((Diagnostic) -> Void)? = nil) throws -> SourceFileSyntax {
         // Avoid using `String(contentsOf:)` because it creates a wrapped NSString.
         let source = fileData.withUnsafeBytes { buf in
             return String(decoding: buf.bindMemory(to: UInt8.self), as: UTF8.self)
         }
         return try parse(source: source, filenameForDiagnostics: path,
-                         diagnosticEngine: diagnosticEngine)
+                         diagnosticHandler: diagnosticHandler)
     }
 
     public static func parse(_ path: String) throws -> SourceFileSyntax {


### PR DESCRIPTION
Upgrade the SwiftSyntax lib to 5.6 to support Xcode 13.3 and Swift 5.6.